### PR TITLE
fix bug format character j

### DIFF
--- a/src/Jalali.php
+++ b/src/Jalali.php
@@ -249,7 +249,7 @@ class Jalali extends DateAbstract
                     break;
 
                 case 'j':
-                    $v = sprintf('%01d', $this->jMonth);
+                    $v = sprintf('%01d', $this->jDay);
                     break;
 
                 case 'z':

--- a/tests/JalaliTest.php
+++ b/tests/JalaliTest.php
@@ -56,4 +56,11 @@ class JalaliTest extends TestCase
 
         $this->assertSame('1466664492', $date->format('U'));
     }
+
+    public function testFrotmatJ()
+    {
+        $date = new Jalali('1398/1/5', 'Asia/tehran');
+
+        $this->assertSame('5', $date->format('j'));
+    }
 }


### PR DESCRIPTION
Hi

In php doc format character for j is defined 
`Day of the month without leading zeros | 1 to 31 | `
https://www.php.net/manual/en/function.date.php
